### PR TITLE
Refs #8146 - full and subnet options are flags now

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Or to download a per-host disk, run:
 
     hammer bootdisk host --host client.example.com
 
+Or to download a subnet disk, run:
+
+    hammer bootdisk subnet --subnet mysubnet
+
 Files will be downloaded into the current directory unless `--file` is used to set the
 destination:
 

--- a/lib/hammer_cli_foreman_bootdisk/bootdisk.rb
+++ b/lib/hammer_cli_foreman_bootdisk/bootdisk.rb
@@ -22,6 +22,17 @@ module HammerCLIForemanBootdisk
       build_options
     end
 
+    class SubnetCommand < HammerCLIForemanBootdisk::DownloadCommand
+      resource :subnet_disks
+      action :subnet
+
+      command_name    'subnet'
+      success_message _('Successfully downloaded subnet disk image to %s')
+      failure_message _('Failed to download subnet disk image')
+
+      build_options
+    end
+
     autoload_subcommands
   end
 end


### PR DESCRIPTION
This is rather cosmetic change. Without this patch, this does not work
properly:

  host --host mac525400da7561.local.lan --full --subnet

It sends `full="--subnet"` data. You need to type `--full true --subnet true`
which is confusing.
