### PR TITLE
Fixes #11804 : Update the gettext version to be in line with what ham…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ tags
 
 # Disks
 *.iso
+
+# Locale files
+locale/*/*.edit.po
+locale/*/*.po.time_stamp

--- a/.tx/config
+++ b/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [foreman.hammer_cli_foreman_bootdisk]
-file_filter = locale/<lang>/hammer_cli_foreman_bootdisk.po
+file_filter = locale/<lang>/hammer_cli_foreman_bootdisk.edit.po
 source_file = locale/hammer_cli_foreman_bootdisk.pot
 source_lang = en
 type = PO

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem 'rake'
 # for generating i18n files, gettext > 3.0 dropped ruby 1.8 support
-gem 'gettext', '~> 2.0'
+gem 'gettext', '>= 3.1.3', '< 4.0.0'
 
 # load local gemfile
 local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local')

--- a/Rakefile
+++ b/Rakefile
@@ -2,14 +2,27 @@ require 'bundler/gem_tasks'
 
 namespace :gettext do
   desc "Update pot file"
-  task :find do
+  task :setup do
     require "hammer_cli_foreman_bootdisk/version"
     require "hammer_cli_foreman_bootdisk/i18n"
-    require 'gettext/tools'
+    require 'gettext/tools/task'
 
     domain = HammerCLIForemanBootdisk::I18n::LocaleDomain.new
-    GetText.update_pofiles(domain.domain_name, domain.translated_files, "#{domain.domain_name} #{HammerCLIForemanBootdisk.version.to_s}", :po_root => domain.locale_dir)
+    GetText::Tools::Task.define do |task|
+      task.package_name = domain.domain_name
+      task.package_version = HammerCLIForemanBootdisk.version.to_s
+      task.domain = domain.domain_name
+      task.mo_base_directory = domain.locale_dir
+      task.po_base_directory = domain.locale_dir
+      task.files = domain.translated_files
+    end
   end
+
+  desc "Update pot file"
+  task :find => [:setup] do
+    Rake::Task["gettext:po:update"].invoke
+  end
+
 end
 
 namespace :pkg do

--- a/locale/Makefile
+++ b/locale/Makefile
@@ -10,9 +10,10 @@ DOMAIN = hammer_cli_foreman_bootdisk
 VERSION = $(shell ruby -e 'require "rubygems";spec = Gem::Specification::load("../hammer_cli_foreman_bootdisk.gemspec");puts spec.version')
 POTFILE = $(DOMAIN).pot
 MOFILE = $(DOMAIN).mo
-POFILES = $(shell find . -name '*.po')
+POFILES = $(shell find . -name '$(DOMAIN).po')
 MOFILES = $(patsubst %.po,%.mo,$(POFILES))
 POXFILES = $(patsubst %.po,%.pox,$(POFILES))
+EDITFILES = $(patsubst %.po,%.edit.po,$(POFILES))
 
 %.mo: %.po
 	mkdir -p $(shell dirname $@)/LC_MESSAGES
@@ -30,13 +31,6 @@ all-mo: $(MOFILES)
 	! grep -q msgid $@
 
 check: $(POXFILES)
-	msgfmt -c ${POTFILE}
-
-# Merge PO files
-update-po:
-	for f in $(shell find ./ -name "*.po") ; do \
-		msgmerge -N --backup=none -U $$f ${POTFILE} ; \
-	done
 
 # Unify duplicate translations
 uniq-po:
@@ -44,22 +38,20 @@ uniq-po:
 		msguniq $$f -o $$f ; \
 	done
 
-tx-pull:
+tx-pull: $(EDITFILES)
 	tx pull -f
 	for f in $(POFILES) ; do \
 		sed -i 's/^\("Project-Id-Version: \).*$$/\1$(DOMAIN) $(VERSION)\\n"/' $$f; \
 	done
-	-git commit -a -m "i18n - extracting new, pulling from tx"
 
+# Extract strings and update the .pot, prepare .edit.po files
 extract-strings:
 	bundle exec rake gettext:find
 
-reset-po:
-	# merging po files is unnecessary when using transifex.com
-	git checkout -- ../locale/*/*po
+# Merge .edit.po into .po
+update-po:
+	bundle exec rake gettext:find
 
-tx-update: tx-pull extract-strings reset-po $(MOFILES)
-	# amend mo files
-	git add ../locale/*/LC_MESSAGES
-	git commit -a --amend -m "i18n - extracting new, pulling from tx"
+tx-update: extract-strings tx-pull update-po $(MOFILES)
+	git commit -m "i18n - extracting new, pulling from tx" ../locale
 	-echo Changes commited!

--- a/locale/ca/hammer_cli_foreman_bootdisk.po
+++ b/locale/ca/hammer_cli_foreman_bootdisk.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer_cli_foreman_bootdisk package.
 # Dominic Cleal <dcleal@redhat.com>, 2014
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_bootdisk 0.1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-10 12:48+0000\n"
 "PO-Revision-Date: 2014-08-08 14:24+0100\n"
 "Last-Translator: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -18,48 +16,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:6
-msgid "File or device to write image to"
+msgid "Download boot disks"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:7
-msgid "Force writing to existing destination (device etc.)"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:8
-msgid "Use sudo to write to device"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:14
-msgid ""
-"Destination %s already exists and isn't a regular file, use '--force' if you "
-"are sure you wish to write to it"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:9
 msgid "Successfully downloaded generic disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:10
 msgid "Failed to download generic disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:19
 msgid "Successfully downloaded host disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:20
 msgid "Failed to download host disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:30
 msgid "Successfully downloaded subnet disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:31
 msgid "Failed to download subnet disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk.rb:12
-msgid "Download boot disks"
+msgid "File or device to write image to"
+msgstr ""
+
+msgid "Force writing to existing destination (device etc.)"
+msgstr ""
+
+msgid "Use sudo to write to device"
+msgstr ""
+
+msgid ""
+"Destination %s already exists and isn't a regular file, use '--force' if you a"
+"re sure you wish to write to it"
 msgstr ""

--- a/locale/de/hammer_cli_foreman_bootdisk.po
+++ b/locale/de/hammer_cli_foreman_bootdisk.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer_cli_foreman_bootdisk package.
 # Dominic Cleal <dcleal@redhat.com>, 2014
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_bootdisk 0.1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-10 12:48+0000\n"
 "PO-Revision-Date: 2014-08-08 14:24+0100\n"
 "Last-Translator: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -18,48 +16,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:6
-msgid "File or device to write image to"
+msgid "Download boot disks"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:7
-msgid "Force writing to existing destination (device etc.)"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:8
-msgid "Use sudo to write to device"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:14
-msgid ""
-"Destination %s already exists and isn't a regular file, use '--force' if you "
-"are sure you wish to write to it"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:9
 msgid "Successfully downloaded generic disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:10
 msgid "Failed to download generic disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:19
 msgid "Successfully downloaded host disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:20
 msgid "Failed to download host disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:30
 msgid "Successfully downloaded subnet disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:31
 msgid "Failed to download subnet disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk.rb:12
-msgid "Download boot disks"
+msgid "File or device to write image to"
+msgstr ""
+
+msgid "Force writing to existing destination (device etc.)"
+msgstr ""
+
+msgid "Use sudo to write to device"
+msgstr ""
+
+msgid ""
+"Destination %s already exists and isn't a regular file, use '--force' if you a"
+"re sure you wish to write to it"
 msgstr ""

--- a/locale/en/hammer_cli_foreman_bootdisk.po
+++ b/locale/en/hammer_cli_foreman_bootdisk.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer_cli_foreman_bootdisk package.
 # Dominic Cleal <dcleal@redhat.com>, 2014
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_bootdisk 0.1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-10 12:48+0000\n"
 "PO-Revision-Date: 2014-08-08 14:24+0100\n"
 "Last-Translator: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -18,48 +16,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:6
-msgid "File or device to write image to"
+msgid "Download boot disks"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:7
-msgid "Force writing to existing destination (device etc.)"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:8
-msgid "Use sudo to write to device"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:14
-msgid ""
-"Destination %s already exists and isn't a regular file, use '--force' if you "
-"are sure you wish to write to it"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:9
 msgid "Successfully downloaded generic disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:10
 msgid "Failed to download generic disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:19
 msgid "Successfully downloaded host disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:20
 msgid "Failed to download host disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:30
 msgid "Successfully downloaded subnet disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:31
 msgid "Failed to download subnet disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk.rb:12
-msgid "Download boot disks"
+msgid "File or device to write image to"
+msgstr ""
+
+msgid "Force writing to existing destination (device etc.)"
+msgstr ""
+
+msgid "Use sudo to write to device"
+msgstr ""
+
+msgid ""
+"Destination %s already exists and isn't a regular file, use '--force' if you a"
+"re sure you wish to write to it"
 msgstr ""

--- a/locale/en_GB/hammer_cli_foreman_bootdisk.po
+++ b/locale/en_GB/hammer_cli_foreman_bootdisk.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer_cli_foreman_bootdisk package.
 # Dominic Cleal <dcleal@redhat.com>, 2014
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_bootdisk 0.1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-10 12:48+0000\n"
 "PO-Revision-Date: 2014-08-08 14:24+0100\n"
 "Last-Translator: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -18,48 +16,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:6
-msgid "File or device to write image to"
+msgid "Download boot disks"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:7
-msgid "Force writing to existing destination (device etc.)"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:8
-msgid "Use sudo to write to device"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:14
-msgid ""
-"Destination %s already exists and isn't a regular file, use '--force' if you "
-"are sure you wish to write to it"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:9
 msgid "Successfully downloaded generic disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:10
 msgid "Failed to download generic disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:19
 msgid "Successfully downloaded host disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:20
 msgid "Failed to download host disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:30
 msgid "Successfully downloaded subnet disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:31
 msgid "Failed to download subnet disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk.rb:12
-msgid "Download boot disks"
+msgid "File or device to write image to"
+msgstr ""
+
+msgid "Force writing to existing destination (device etc.)"
+msgstr ""
+
+msgid "Use sudo to write to device"
+msgstr ""
+
+msgid ""
+"Destination %s already exists and isn't a regular file, use '--force' if you a"
+"re sure you wish to write to it"
 msgstr ""

--- a/locale/es/hammer_cli_foreman_bootdisk.po
+++ b/locale/es/hammer_cli_foreman_bootdisk.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer_cli_foreman_bootdisk package.
 # Dominic Cleal <dcleal@redhat.com>, 2014
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_bootdisk 0.1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-10 12:48+0000\n"
 "PO-Revision-Date: 2014-08-08 14:24+0100\n"
 "Last-Translator: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -18,48 +16,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:6
-msgid "File or device to write image to"
+msgid "Download boot disks"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:7
-msgid "Force writing to existing destination (device etc.)"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:8
-msgid "Use sudo to write to device"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:14
-msgid ""
-"Destination %s already exists and isn't a regular file, use '--force' if you "
-"are sure you wish to write to it"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:9
 msgid "Successfully downloaded generic disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:10
 msgid "Failed to download generic disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:19
 msgid "Successfully downloaded host disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:20
 msgid "Failed to download host disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:30
 msgid "Successfully downloaded subnet disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:31
 msgid "Failed to download subnet disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk.rb:12
-msgid "Download boot disks"
+msgid "File or device to write image to"
+msgstr ""
+
+msgid "Force writing to existing destination (device etc.)"
+msgstr ""
+
+msgid "Use sudo to write to device"
+msgstr ""
+
+msgid ""
+"Destination %s already exists and isn't a regular file, use '--force' if you a"
+"re sure you wish to write to it"
 msgstr ""

--- a/locale/fr/hammer_cli_foreman_bootdisk.po
+++ b/locale/fr/hammer_cli_foreman_bootdisk.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer_cli_foreman_bootdisk package.
 # Dominic Cleal <dcleal@redhat.com>, 2014
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_bootdisk 0.1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-10 12:48+0000\n"
 "PO-Revision-Date: 2014-08-08 14:24+0100\n"
 "Last-Translator: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -18,48 +16,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:6
-msgid "File or device to write image to"
+msgid "Download boot disks"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:7
-msgid "Force writing to existing destination (device etc.)"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:8
-msgid "Use sudo to write to device"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:14
-msgid ""
-"Destination %s already exists and isn't a regular file, use '--force' if you "
-"are sure you wish to write to it"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:9
 msgid "Successfully downloaded generic disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:10
 msgid "Failed to download generic disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:19
 msgid "Successfully downloaded host disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:20
 msgid "Failed to download host disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:30
 msgid "Successfully downloaded subnet disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:31
 msgid "Failed to download subnet disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk.rb:12
-msgid "Download boot disks"
+msgid "File or device to write image to"
+msgstr ""
+
+msgid "Force writing to existing destination (device etc.)"
+msgstr ""
+
+msgid "Use sudo to write to device"
+msgstr ""
+
+msgid ""
+"Destination %s already exists and isn't a regular file, use '--force' if you a"
+"re sure you wish to write to it"
 msgstr ""

--- a/locale/it/hammer_cli_foreman_bootdisk.po
+++ b/locale/it/hammer_cli_foreman_bootdisk.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer_cli_foreman_bootdisk package.
 # Dominic Cleal <dcleal@redhat.com>, 2014
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_bootdisk 0.1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-10 12:48+0000\n"
 "PO-Revision-Date: 2014-08-08 14:24+0100\n"
 "Last-Translator: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -18,48 +16,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:6
-msgid "File or device to write image to"
+msgid "Download boot disks"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:7
-msgid "Force writing to existing destination (device etc.)"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:8
-msgid "Use sudo to write to device"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:14
-msgid ""
-"Destination %s already exists and isn't a regular file, use '--force' if you "
-"are sure you wish to write to it"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:9
 msgid "Successfully downloaded generic disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:10
 msgid "Failed to download generic disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:19
 msgid "Successfully downloaded host disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:20
 msgid "Failed to download host disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:30
 msgid "Successfully downloaded subnet disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:31
 msgid "Failed to download subnet disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk.rb:12
-msgid "Download boot disks"
+msgid "File or device to write image to"
+msgstr ""
+
+msgid "Force writing to existing destination (device etc.)"
+msgstr ""
+
+msgid "Use sudo to write to device"
+msgstr ""
+
+msgid ""
+"Destination %s already exists and isn't a regular file, use '--force' if you a"
+"re sure you wish to write to it"
 msgstr ""

--- a/locale/ja/hammer_cli_foreman_bootdisk.po
+++ b/locale/ja/hammer_cli_foreman_bootdisk.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer_cli_foreman_bootdisk package.
 # Dominic Cleal <dcleal@redhat.com>, 2014
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_bootdisk 0.1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-10 12:48+0000\n"
 "PO-Revision-Date: 2014-08-08 14:24+0100\n"
 "Last-Translator: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -18,48 +16,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:6
-msgid "File or device to write image to"
+msgid "Download boot disks"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:7
-msgid "Force writing to existing destination (device etc.)"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:8
-msgid "Use sudo to write to device"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:14
-msgid ""
-"Destination %s already exists and isn't a regular file, use '--force' if you "
-"are sure you wish to write to it"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:9
 msgid "Successfully downloaded generic disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:10
 msgid "Failed to download generic disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:19
 msgid "Successfully downloaded host disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:20
 msgid "Failed to download host disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:30
 msgid "Successfully downloaded subnet disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:31
 msgid "Failed to download subnet disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk.rb:12
-msgid "Download boot disks"
+msgid "File or device to write image to"
+msgstr ""
+
+msgid "Force writing to existing destination (device etc.)"
+msgstr ""
+
+msgid "Use sudo to write to device"
+msgstr ""
+
+msgid ""
+"Destination %s already exists and isn't a regular file, use '--force' if you a"
+"re sure you wish to write to it"
 msgstr ""

--- a/locale/ko/hammer_cli_foreman_bootdisk.po
+++ b/locale/ko/hammer_cli_foreman_bootdisk.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer_cli_foreman_bootdisk package.
 # Dominic Cleal <dcleal@redhat.com>, 2014
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_bootdisk 0.1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-10 12:48+0000\n"
 "PO-Revision-Date: 2014-08-08 14:24+0100\n"
 "Last-Translator: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -18,48 +16,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:6
-msgid "File or device to write image to"
+msgid "Download boot disks"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:7
-msgid "Force writing to existing destination (device etc.)"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:8
-msgid "Use sudo to write to device"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:14
-msgid ""
-"Destination %s already exists and isn't a regular file, use '--force' if you "
-"are sure you wish to write to it"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:9
 msgid "Successfully downloaded generic disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:10
 msgid "Failed to download generic disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:19
 msgid "Successfully downloaded host disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:20
 msgid "Failed to download host disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:30
 msgid "Successfully downloaded subnet disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:31
 msgid "Failed to download subnet disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk.rb:12
-msgid "Download boot disks"
+msgid "File or device to write image to"
+msgstr ""
+
+msgid "Force writing to existing destination (device etc.)"
+msgstr ""
+
+msgid "Use sudo to write to device"
+msgstr ""
+
+msgid ""
+"Destination %s already exists and isn't a regular file, use '--force' if you a"
+"re sure you wish to write to it"
 msgstr ""

--- a/locale/pt_BR/hammer_cli_foreman_bootdisk.po
+++ b/locale/pt_BR/hammer_cli_foreman_bootdisk.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer_cli_foreman_bootdisk package.
 # Dominic Cleal <dcleal@redhat.com>, 2014
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_bootdisk 0.1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-10 12:48+0000\n"
 "PO-Revision-Date: 2014-08-08 14:24+0100\n"
 "Last-Translator: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -18,48 +16,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:6
-msgid "File or device to write image to"
+msgid "Download boot disks"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:7
-msgid "Force writing to existing destination (device etc.)"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:8
-msgid "Use sudo to write to device"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:14
-msgid ""
-"Destination %s already exists and isn't a regular file, use '--force' if you "
-"are sure you wish to write to it"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:9
 msgid "Successfully downloaded generic disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:10
 msgid "Failed to download generic disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:19
 msgid "Successfully downloaded host disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:20
 msgid "Failed to download host disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:30
 msgid "Successfully downloaded subnet disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:31
 msgid "Failed to download subnet disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk.rb:12
-msgid "Download boot disks"
+msgid "File or device to write image to"
+msgstr ""
+
+msgid "Force writing to existing destination (device etc.)"
+msgstr ""
+
+msgid "Use sudo to write to device"
+msgstr ""
+
+msgid ""
+"Destination %s already exists and isn't a regular file, use '--force' if you a"
+"re sure you wish to write to it"
 msgstr ""

--- a/locale/ru/hammer_cli_foreman_bootdisk.po
+++ b/locale/ru/hammer_cli_foreman_bootdisk.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer_cli_foreman_bootdisk package.
 # Dominic Cleal <dcleal@redhat.com>, 2014
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_bootdisk 0.1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-10 12:48+0000\n"
 "PO-Revision-Date: 2014-08-08 14:24+0100\n"
 "Last-Translator: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -18,48 +16,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:6
-msgid "File or device to write image to"
+msgid "Download boot disks"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:7
-msgid "Force writing to existing destination (device etc.)"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:8
-msgid "Use sudo to write to device"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:14
-msgid ""
-"Destination %s already exists and isn't a regular file, use '--force' if you "
-"are sure you wish to write to it"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:9
 msgid "Successfully downloaded generic disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:10
 msgid "Failed to download generic disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:19
 msgid "Successfully downloaded host disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:20
 msgid "Failed to download host disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:30
 msgid "Successfully downloaded subnet disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:31
 msgid "Failed to download subnet disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk.rb:12
-msgid "Download boot disks"
+msgid "File or device to write image to"
+msgstr ""
+
+msgid "Force writing to existing destination (device etc.)"
+msgstr ""
+
+msgid "Use sudo to write to device"
+msgstr ""
+
+msgid ""
+"Destination %s already exists and isn't a regular file, use '--force' if you a"
+"re sure you wish to write to it"
 msgstr ""

--- a/locale/zh_CN/hammer_cli_foreman_bootdisk.po
+++ b/locale/zh_CN/hammer_cli_foreman_bootdisk.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer_cli_foreman_bootdisk package.
 # Dominic Cleal <dcleal@redhat.com>, 2014
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_bootdisk 0.1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-10 12:48+0000\n"
 "PO-Revision-Date: 2014-08-08 14:24+0100\n"
 "Last-Translator: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -18,48 +16,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:6
-msgid "File or device to write image to"
+msgid "Download boot disks"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:7
-msgid "Force writing to existing destination (device etc.)"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:8
-msgid "Use sudo to write to device"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:14
-msgid ""
-"Destination %s already exists and isn't a regular file, use '--force' if you "
-"are sure you wish to write to it"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:9
 msgid "Successfully downloaded generic disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:10
 msgid "Failed to download generic disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:19
 msgid "Successfully downloaded host disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:20
 msgid "Failed to download host disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:30
 msgid "Successfully downloaded subnet disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:31
 msgid "Failed to download subnet disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk.rb:12
-msgid "Download boot disks"
+msgid "File or device to write image to"
+msgstr ""
+
+msgid "Force writing to existing destination (device etc.)"
+msgstr ""
+
+msgid "Use sudo to write to device"
+msgstr ""
+
+msgid ""
+"Destination %s already exists and isn't a regular file, use '--force' if you a"
+"re sure you wish to write to it"
 msgstr ""

--- a/locale/zh_TW/hammer_cli_foreman_bootdisk.po
+++ b/locale/zh_TW/hammer_cli_foreman_bootdisk.po
@@ -3,12 +3,10 @@
 # This file is distributed under the same license as the hammer_cli_foreman_bootdisk package.
 # Dominic Cleal <dcleal@redhat.com>, 2014
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: hammer_cli_foreman_bootdisk 0.1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-10 12:48+0000\n"
 "PO-Revision-Date: 2014-08-08 14:24+0100\n"
 "Last-Translator: Foreman Team <foreman-dev@googlegroups.com>\n"
 "Language-Team: Foreman Team <foreman-dev@googlegroups.com>\n"
@@ -18,48 +16,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:6
-msgid "File or device to write image to"
+msgid "Download boot disks"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:7
-msgid "Force writing to existing destination (device etc.)"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:8
-msgid "Use sudo to write to device"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/commands.rb:14
-msgid ""
-"Destination %s already exists and isn't a regular file, use '--force' if you "
-"are sure you wish to write to it"
-msgstr ""
-
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:9
 msgid "Successfully downloaded generic disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:10
 msgid "Failed to download generic disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:19
 msgid "Successfully downloaded host disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:20
 msgid "Failed to download host disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:30
 msgid "Successfully downloaded subnet disk image to %s"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk/bootdisk.rb:31
 msgid "Failed to download subnet disk image"
 msgstr ""
 
-#: lib/hammer_cli_foreman_bootdisk.rb:12
-msgid "Download boot disks"
+msgid "File or device to write image to"
+msgstr ""
+
+msgid "Force writing to existing destination (device etc.)"
+msgstr ""
+
+msgid "Use sudo to write to device"
+msgstr ""
+
+msgid ""
+"Destination %s already exists and isn't a regular file, use '--force' if you a"
+"re sure you wish to write to it"
 msgstr ""


### PR DESCRIPTION
…mer-cli uses

This includes Gemfile changes, Rakefile changes, and .gitignore and transifex
changes for the edit.po and timestamp files.
