### PR TITLE
Update rake version to 13.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
-gem 'rake', '~> 10.1.0'
+gem 'rake', '~> 13.1.0'
 
 # load local gemfile
 ['Gemfile.local.rb', 'Gemfile.local'].map do |file_name|


### PR DESCRIPTION
Currently pinned version of Rake doesn't work well with Ruby 3.0+.
Updating to the version currently used by hammer-cli (13.1.0).

Without this, some gettext commands fail.