### PR TITLE
Use theforeman-rubocop gemspec

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,3 +14,5 @@ jobs:
   rubocop:
     name: Rubocop
     uses: theforeman/actions/.github/workflows/rubocop.yml@v0
+    with:
+      command: bundle exec rubocop --parallel --format github

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,3 @@ Metrics:
 
 Style/StringLiterals:
   Enabled: false
-
-Style/FrozenStringLiteralComment:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,3 @@ Layout/LineLength:
 
 Metrics:
   Enabled: false
-
-Style/StringLiterals:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,8 +5,5 @@ inherit_gem:
 AllCops:
   TargetRubyVersion: 2.7
 
-Layout/LineLength:
-  Enabled: false
-
 Metrics:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,9 @@
-require:
-  - rubocop-performance
+inherit_gem:
+  theforeman-rubocop:
+    - strictest.yml
 
 AllCops:
-  NewCops: enable
+  TargetRubyVersion: 2.7
 
 Layout/LineLength:
   Enabled: false
@@ -10,17 +11,8 @@ Layout/LineLength:
 Metrics:
   Enabled: false
 
-Style/Documentation:
-  Enabled: false
-
 Style/StringLiterals:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Gemspec/RequireMFA:
-  Enabled: false
-
-Style/SymbolProc:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,6 @@ gemspec
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
 gem 'rake', '~> 13.1.0'
 
-group :test do
-  gem 'rubocop', '~> 1.57.0'
-  gem 'rubocop-performance', '~> 1.5.2'
-end
-
 # load local gemfile
 ['Gemfile.local.rb', 'Gemfile.local'].map do |file_name|
   local_gemfile = File.join(File.dirname(__FILE__), file_name)

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake/testtask'
 require 'bundler/gem_tasks'
 require 'hammer_cli/i18n/find_task'

--- a/hammer_cli_foreman_bootdisk.gemspec
+++ b/hammer_cli_foreman_bootdisk.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'hammer_cli_foreman', '~> 3.10'
   s.required_ruby_version = '>= 2.7', '< 4'
+
+  s.add_development_dependency 'theforeman-rubocop', '~> 0.1.0'
 end

--- a/hammer_cli_foreman_bootdisk.gemspec
+++ b/hammer_cli_foreman_bootdisk.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require "hammer_cli_foreman_bootdisk/version"
 

--- a/hammer_cli_foreman_bootdisk.gemspec
+++ b/hammer_cli_foreman_bootdisk.gemspec
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require "hammer_cli_foreman_bootdisk/version"
+require 'hammer_cli_foreman_bootdisk/version'
 
 Gem::Specification.new do |s|
-  s.name          = "hammer_cli_foreman_bootdisk"
+  s.name          = 'hammer_cli_foreman_bootdisk'
   s.version       = HammerCLIForemanBootdisk.version.dup
   s.platform      = Gem::Platform::RUBY
-  s.authors       = ["Dominic Cleal"]
-  s.email         = "dcleal@redhat.com"
-  s.homepage      = "https://github.com/theforeman/hammer_cli_foreman_bootdisk"
-  s.license       = "GPL-3.0+"
+  s.authors       = ['Dominic Cleal']
+  s.email         = 'dcleal@redhat.com'
+  s.homepage      = 'https://github.com/theforeman/hammer_cli_foreman_bootdisk'
+  s.license       = 'GPL-3.0+'
 
   s.summary       = 'Foreman boot disk commands for Hammer'
   s.description   = 'Foreman boot disk commands for Hammer CLI'
 
   s.files            = Dir['{config,lib,locale}/**/*', 'LICENSE', 'README*']
   s.extra_rdoc_files = Dir['LICENSE', 'README*']
-  s.require_paths = ["lib"]
+  s.require_paths = ['lib']
 
   s.add_dependency 'hammer_cli_foreman', '~> 3.10'
   s.required_ruby_version = '>= 2.7', '< 4'

--- a/lib/hammer_cli_foreman_bootdisk.rb
+++ b/lib/hammer_cli_foreman_bootdisk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'hammer_cli_foreman'
 
 module HammerCLIForemanBootdisk

--- a/lib/hammer_cli_foreman_bootdisk.rb
+++ b/lib/hammer_cli_foreman_bootdisk.rb
@@ -11,7 +11,7 @@ module HammerCLIForemanBootdisk
     require 'hammer_cli_foreman_bootdisk/commands'
     require 'hammer_cli_foreman_bootdisk/version'
 
-    HammerCLI::MainCommand.lazy_subcommand('bootdisk', _("Download boot disks"),
+    HammerCLI::MainCommand.lazy_subcommand('bootdisk', _('Download boot disks'),
       'HammerCLIForemanBootdisk::Bootdisk', 'hammer_cli_foreman_bootdisk/bootdisk')
   rescue StandardError => e
     handler = HammerCLIForeman::ExceptionHandler.new(context: {}, adapter: :base)

--- a/lib/hammer_cli_foreman_bootdisk.rb
+++ b/lib/hammer_cli_foreman_bootdisk.rb
@@ -10,7 +10,7 @@ module HammerCLIForemanBootdisk
     require 'hammer_cli_foreman_bootdisk/version'
 
     HammerCLI::MainCommand.lazy_subcommand('bootdisk', _("Download boot disks"),
-                                           'HammerCLIForemanBootdisk::Bootdisk', 'hammer_cli_foreman_bootdisk/bootdisk')
+      'HammerCLIForemanBootdisk::Bootdisk', 'hammer_cli_foreman_bootdisk/bootdisk')
   rescue StandardError => e
     handler = HammerCLIForeman::ExceptionHandler.new(context: {}, adapter: :base)
     handler.handle_exception(e)

--- a/lib/hammer_cli_foreman_bootdisk/bootdisk.rb
+++ b/lib/hammer_cli_foreman_bootdisk/bootdisk.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HammerCLIForemanBootdisk
   class Bootdisk < HammerCLIForeman::Command
     resource :disks

--- a/lib/hammer_cli_foreman_bootdisk/commands.rb
+++ b/lib/hammer_cli_foreman_bootdisk/commands.rb
@@ -5,9 +5,9 @@ require 'hammer_cli_foreman/commands'
 
 module HammerCLIForemanBootdisk
   class DownloadCommand < HammerCLIForeman::Command
-    option "--file", "PATH", _("File or device to write image to")
-    option "--force", :flag, _("Force writing to existing destination (device etc.)")
-    option "--sudo", :flag, _("Use sudo to write to device")
+    option '--file', 'PATH', _('File or device to write image to')
+    option '--force', :flag, _('Force writing to existing destination (device etc.)')
+    option '--sudo', :flag, _('Use sudo to write to device')
 
     def print_data(record)
       server_filename = ::Regexp.last_match(1) if record.headers[:content_disposition].match?(/filename=["']?([^\s,;"']+)/)

--- a/lib/hammer_cli_foreman_bootdisk/commands.rb
+++ b/lib/hammer_cli_foreman_bootdisk/commands.rb
@@ -9,6 +9,7 @@ module HammerCLIForemanBootdisk
     option '--force', :flag, _('Force writing to existing destination (device etc.)')
     option '--sudo', :flag, _('Use sudo to write to device')
 
+    # rubocop:disable Layout/LineLength
     def print_data(record)
       server_filename = ::Regexp.last_match(1) if record.headers[:content_disposition].match?(/filename=["']?([^\s,;"']+)/)
       file = options[HammerCLI.option_accessor_name('file')] || server_filename || 'bootdisk.iso'
@@ -28,6 +29,7 @@ module HammerCLIForemanBootdisk
       end
       print_message(success_message % file) if success_message
     end
+    # rubocop:enable Layout/LineLength
 
     def request_options
       { response: :raw }

--- a/lib/hammer_cli_foreman_bootdisk/commands.rb
+++ b/lib/hammer_cli_foreman_bootdisk/commands.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tempfile'
 require 'hammer_cli_foreman/commands'
 

--- a/lib/hammer_cli_foreman_bootdisk/i18n.rb
+++ b/lib/hammer_cli_foreman_bootdisk/i18n.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'hammer_cli/i18n'
 
 module HammerCLIForemanBootdisk

--- a/lib/hammer_cli_foreman_bootdisk/version.rb
+++ b/lib/hammer_cli_foreman_bootdisk/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HammerCLIForemanBootdisk
   def self.version
     @version ||= Gem::Version.new '0.4.1'


### PR DESCRIPTION
Inherited strictest.yml here, this rules have NewCops enable config. Also dropped Style/HashSyntax, Gemspec/RequireMFA and Style/SymbolProc from here because that was either included in the inherit file or was not needed.

This is part of Rubocop standerdization, link for the reference:
https://community.theforeman.org/t/standardizing-rubocop-with-theforeman-rubocop/37239
https://github.com/theforeman/theforeman-rubocop/?tab=readme-ov-file#all-opinionated-cops-with-new-ones---strictest